### PR TITLE
Update config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -50,7 +50,7 @@ define([], function () {
         VimeoVideoUrl: "https://player.vimeo.com/video/",
 
         // The URL for your ArcGIS Online Organization or Portal for ArcGIS site,
-        // e.g., something like "https://myOrg.maps.arcgis.com/" for an Online Organization
+        // e.g., something like "https://myOrg.maps.arcgis.com" for an Online Organization
         PortalURL: "",
 
         // OAuth application id; This parameter is only required for ArcGIS organizational accounts using Enterprise Logins.Leave empty if you are not using Enterprise Logins


### PR DESCRIPTION
Edit to line 53 in the comment. Change example url from "https://myOrg.maps.arcgis.com/" to "https://myOrg.maps.arcgis.com" because if using OAuth for authentication, line 164 in mapBookConfigLoader.js will be equal to false (because the PortalURL does not match the same format as idObject.credentials[i].server) when it should read true.